### PR TITLE
Fix index out of bounds when using Pygame 2.0

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -21,9 +21,8 @@ def update_keyboard_menu(menu_spot, last_toggle, debug_state, frame):
     pressed = pygame.key.get_pressed()  # Make a list of every key that is being pressed down.
 
     if frame == 1:  # Fixes bug in which pressed from last game can move the cursor to quit on first frame
-        pressed = []
-        for i in range(0, 300):
-            pressed.append(0)
+        for x in pressed:
+            x = False
 
     if pressed[pygame.K_c] and time.time() >= last_toggle + TOGGLE_DEBUFFER:
         # Toggles cheat mode. assuming enough time has passed


### PR DESCRIPTION
Pygame 2.0 changed the constants for keyboard input. The code for
having no keyboard input on the first frame assumed that the list of
keys was a certain length, so I changed the code to just clear the list
given.

Fixes #1